### PR TITLE
Production build fix

### DIFF
--- a/dist/src/prism.component.d.ts
+++ b/dist/src/prism.component.d.ts
@@ -1,4 +1,9 @@
-import { Renderer2, ElementRef, AfterViewInit } from '@angular/core';
+import { Directive, Renderer2, ElementRef, AfterViewInit } from '@angular/core';
+
+@Directive({
+	selector: 'arbitrary'	// Can be named anything you want
+})
+
 export declare class PrismComponent implements AfterViewInit {
     private _renderer;
     private _el;


### PR DESCRIPTION
I have added a Directive decorator to the dist/prism.component.d.ts which fixes an error when compiling this component into a production build in Angular 5. Without this, it returns a decorator error. Otherwise, I was required to put the full path name to the node_modules folder for this particular node module. Please note that the Directive selector property is not used and therefor is arbitrary. 

Thank you in advance.
This is one very useful Angular 5 component that I am using all the time and want to continue to do so.
Please contact me if you have questions concerning this pull request.

Please reference the following error:

> ERROR in : Unexpected value 'PrismComponent in /Users/dmytrieck/Documents/TCG/Dataweb/node_modules/angular-prism/dist/angular-prism.js' declared by the module 'ViewsModule in /Users/dmytrieck/Documents/TCG/Dataweb/src/app/modules/views/views.module.ts'. Please add a @Pipe/@Directive/@Component annotation.